### PR TITLE
Add MDI-Enabled Tinker as a Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "modules/Tinker"]
+	path = modules/Tinker
+	url = git@github.com:MolSSI-MDI/Tinker.git
+	branch = mdi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "modules/Tinker"]
 	path = modules/Tinker
-	url = git@github.com:MolSSI-MDI/Tinker.git
+	url = https://github.com/MolSSI-MDI/Tinker.git
 	branch = mdi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,23 +28,10 @@ matrix:
         # Install dependencies
         - conda install -c conda-forge numpy pandas pytest pytest-cov
 
-        # Install Tinker
-        - git clone https://github.com/WelbornGroup/Tinker_ELECTRIC.git
-        - cd Tinker_ELECTRIC/dev
-        - ./full_build.sh
-        - cd ../../
-
       install:
-        - cmake .
-        - make
+        - ./build.sh
 
       script:
-        # Set location of codes
-        - BASE_PATH=$(pwd)
-        - echo $BASE_PATH
-        - echo "${BASE_PATH}/ELECTRIC/ELECTRIC.py" > ${BASE_PATH}/test/locations/ELECTRIC
-        - echo "${BASE_PATH}/Tinker_ELECTRIC/build/tinker/source/dynamic.x" > ${BASE_PATH}/test/locations/Tinker
-
         # Run pytest
         - cd ELECTRIC/pytest
         - pytest -vv --cov-report=xml --cov=ELECTRIC --cov=util

--- a/ELECTRIC/pytest/bench5/test_simulation.py
+++ b/ELECTRIC/pytest/bench5/test_simulation.py
@@ -19,7 +19,7 @@ def format_return(input_string):
 def test_bench5():
     # get the name of the codes
     driver_path = os.path.join(mypath, "../../ELECTRIC.py")
-    engine_path = os.path.join(mypath, "../../../Tinker_ELECTRIC/build/tinker/source/dynamic.x")
+    engine_path = os.path.join(mypath, "../../../modules/Tinker/build/tinker/source/dynamic.x")
 
     # run the calculation
     driver_proc = subprocess.Popen([sys.executable, driver_path, 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Reproduce the behavior of "readlink -f", in a manner compatible with MacOS
+readlink_f() {
+  filename=$1
+
+  cd `dirname $filename`
+  filename=`basename $filename`
+
+  while [ -L "$filename" ]
+  do
+      cd `dirname $filename`
+      filename=`basename $filename`
+  done
+
+  real_path=`pwd -P`
+  echo $real_path/$filename
+}
+
+
+cd modules/Tinker/dev
+./full_build.sh
+cd ../build/tinker/source
+readlink_f dynamic.x > ../../../../../test/locations/Tinker_ELECTRIC
+cd ../../../../../
+cmake .
+make
+cd ELECTRIC
+readlink_f ELECTRIC.py > ../test/locations/ELECTRIC


### PR DESCRIPTION
Following the suggestion of @amandadumi in #17, this PR incorporates an MDI-enabled fork of Tinker into ELECTRIC as a submodule.

This simplifies the build process for users; aside from installing Conda dependencies, the following is sufficient to build and configure both ELECTRIC and MDI-enabled Tinker:

```
git clone --recurse-submodules git@github.com:WelbornGroup/ELECTRIC.git
cd ELECTRIC
./build.sh
```