### PR TITLE
Code clean-up

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,0 +1,12 @@
+## Description
+Provide a brief description of the PR's purpose here.
+
+## Todos
+Notable points that this PR has either accomplished or will accomplish.
+  - [ ] TODO 1
+
+## Questions
+- [ ] Question1
+
+## Status
+- [ ] Ready to go

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# How to contribute
+
+We welcome contributions from external contributors, and this document
+describes how to merge code changes into ELECTRIC. 
+
+## Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* [Fork](https://help.github.com/articles/fork-a-repo/) this repository on GitHub.
+* On your local machine,
+  [clone](https://help.github.com/articles/cloning-a-repository/) your fork of
+  the repository.
+
+## Making Changes
+
+* Add some really awesome code to your local fork.  It's usually a [good
+  idea](http://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)
+  to make changes on a
+  [branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
+  with the branch name relating to the feature you are going to add.
+* When you are ready for others to examine and comment on your new feature,
+  navigate to your fork of ELECTRIC on GitHub and open a [pull
+  request](https://help.github.com/articles/using-pull-requests/) (PR). Note that
+  after you launch a PR from one of your fork's branches, all
+  subsequent commits to that branch will be added to the open pull request
+  automatically.  Each commit added to the PR will be validated for
+  mergability, compilation and test suite compliance; the results of these tests
+  will be visible on the PR page.
+* If you're providing a new feature, you must add test cases and documentation.
+* Please also make sure to run the code formattter [black](https://black.readthedocs.io/en/stable/) 
+  on your code before submitting your pull request.
+* When the code is ready to go, make sure you run the test suite using pytest.
+* When you're ready to be considered for merging, check the "Ready to go"
+  box on the PR page to let the ELECTRIC devs know that the changes are complete.
+  The code will not be merged until this box is checked, the continuous
+  integration returns checkmarks,
+  and multiple core developers give "Approved" reviews.
+
+# Additional Resources
+
+* [General GitHub documentation](https://help.github.com/)
+* [PR best practices](http://codeinthehole.com/writing/pull-requests-and-other-good-practices-for-teams-using-github/)
+* [A guide to contributing to software packages](http://www.contribution-guide.org)
+* [Thinkful PR example](http://www.thinkful.com/learn/github-pull-request-tutorial/#Time-to-Submit-Your-First-PR)

--- a/ELECTRIC/ELECTRIC.py
+++ b/ELECTRIC/ELECTRIC.py
@@ -32,7 +32,8 @@ def connect_to_engines(nengines):
 
     Returns
     -------
-    engine_comm : a list of MDI_Comm values
+    engine_comm : list
+        a list of MDI_Comm values
     """
     # Confirm that this code is being used as a driver
     role = mdi.MDI_Get_Role()
@@ -59,7 +60,7 @@ def connect_to_engines(nengines):
 
     return engine_comm
 
-def collect_task(comm, npoles, snapshot_coords, snap_num, output):
+def collect_task(comm, npoles, snapshot_coords, snap_num, atoms_pole_numbers, output):
     """
     Receive all data associated with an engine's task.
 
@@ -71,18 +72,21 @@ def collect_task(comm, npoles, snapshot_coords, snap_num, output):
     npoles : int
         Number of poles involved in this calculation
 
-    snapshot_coords : NumPy array
+    snapshot_coords : np.ndarray
         Nuclear coordinates at the snapshot associated with this task.
 
     snap_num : int
         The snapshot associated with this task.
+    
+    atoms_pole_numbers : list
+        A multidimensional list where each element gives the pole indices in that fragment.
 
-    output : pd.DataFrame()
+    output : pd.DataFrame
         The aggregated data from all tasks.
 
     Returns
     -------
-    output : pd.DataFrame()
+    output : pd.DataFrame
         The aggregated data from all tasks, including the data collected by this function.
     """
 
@@ -350,7 +354,7 @@ if __name__ == "__main__":
                 if (icomm % nengines) == (nengines - 1):
                     for jcomm in range(nengines):
                         output = collect_task(engine_comm[jcomm], npoles, snapshot_coords[jcomm],
-                                              itask_to_snap_num[itask - nengines + jcomm], output)
+                                              itask_to_snap_num[itask - nengines + jcomm], atoms_pole_numbers, output)
 
                     elapsed_dfield = time.time() - start_dfield
                     print(F"DField Retrieval:\t {elapsed_dfield}")

--- a/ELECTRIC/ELECTRIC.py
+++ b/ELECTRIC/ELECTRIC.py
@@ -11,7 +11,9 @@ import mdi.MDI_Library as mdi
 
 try:
     from mpi4py import MPI
+
     use_mpi4py = True
+
 except ImportError:
     use_mpi4py = False
 
@@ -20,6 +22,7 @@ if use_mpi4py:
     mpi_world = MPI.COMM_WORLD
 else:
     mpi_world = None
+
 
 def connect_to_engines(nengines):
     """
@@ -53,12 +56,13 @@ def connect_to_engines(nengines):
         # Determine the name of the engine
         mdi.MDI_Send_Command("<NAME", comm)
         name = mdi.MDI_Recv(mdi.MDI_NAME_LENGTH, mdi.MDI_CHAR, comm)
-        print(F"Engine name: {name}")
+        print(f"Engine name: {name}")
 
         if name != "NO_EWALD":
             raise Exception("Unrecognized engine name", name)
 
     return engine_comm
+
 
 def collect_task(comm, npoles, snapshot_coords, snap_num, atoms_pole_numbers, output):
     """
@@ -77,7 +81,7 @@ def collect_task(comm, npoles, snapshot_coords, snap_num, atoms_pole_numbers, ou
 
     snap_num : int
         The snapshot associated with this task.
-    
+
     atoms_pole_numbers : list
         A multidimensional list where each element gives the pole indices in that fragment.
 
@@ -90,63 +94,66 @@ def collect_task(comm, npoles, snapshot_coords, snap_num, atoms_pole_numbers, ou
         The aggregated data from all tasks, including the data collected by this function.
     """
 
-    mdi.MDI_Recv(3*npoles*len(probes), mdi.MDI_DOUBLE, comm, buf=dfield)
+    mdi.MDI_Recv(3 * npoles * len(probes), mdi.MDI_DOUBLE, comm, buf=dfield)
 
     # Get the pairwise UFIELD
-    ufield = np.zeros((len(probes),npoles,3))
+    ufield = np.zeros((len(probes), npoles, 3))
     mdi.MDI_Send_Command("<UFIELD", comm)
-    mdi.MDI_Recv(3*npoles*len(probes), mdi.MDI_DOUBLE, comm, buf=ufield)
+    mdi.MDI_Recv(3 * npoles * len(probes), mdi.MDI_DOUBLE, comm, buf=ufield)
 
     # Sum the appropriate values
 
-    columns = ['Probe Atom', 'Probe Coordinates']
-    columns += [F'{by_type} {x}' for x in from_fragment]
+    columns = ["Probe Atom", "Probe Coordinates"]
+    columns += [f"{by_type} {x}" for x in from_fragment]
     dfield_df = pd.DataFrame(columns=columns, index=range(len(probes)))
     ufield_df = pd.DataFrame(columns=columns, index=range(len(probes)))
     totfield_df = pd.DataFrame(columns=columns, index=range(len(probes)))
 
     # Get sum at each probe from fragment.
     for i in range(len(probes)):
-        dfield_df.loc[i, 'Probe Atom'] = probes[i]
-        dfield_df.loc[i, 'Probe Coordinates'] = snapshot_coords[probes[i]-1]
-        ufield_df.loc[i, 'Probe Atom'] = probes[i]
-        ufield_df.loc[i, 'Probe Coordinates'] = snapshot_coords[probes[i]-1]
-        totfield_df.loc[i, 'Probe Atom'] = probes[i]
-        totfield_df.loc[i, 'Probe Coordinates'] = snapshot_coords[probes[i]-1]
+        dfield_df.loc[i, "Probe Atom"] = probes[i]
+        dfield_df.loc[i, "Probe Coordinates"] = snapshot_coords[probes[i] - 1]
+        ufield_df.loc[i, "Probe Atom"] = probes[i]
+        ufield_df.loc[i, "Probe Coordinates"] = snapshot_coords[probes[i] - 1]
+        totfield_df.loc[i, "Probe Atom"] = probes[i]
+        totfield_df.loc[i, "Probe Coordinates"] = snapshot_coords[probes[i] - 1]
 
         for fragment_index, fragment in enumerate(atoms_pole_numbers):
-            fragment_string = F'{by_type} {from_fragment[fragment_index]}'
+            fragment_string = f"{by_type} {from_fragment[fragment_index]}"
             # This uses a numpy array (fragments) for indexing. The fragments
             # array lists pole indices in that fragment. We subtract 1 because
             # python indexes from zero.
-            dfield_df.loc[i, fragment_string] = dfield[i, fragment-1].sum(axis=0)
-            ufield_df.loc[i, fragment_string] = ufield[i, fragment-1].sum(axis=0)
-            totfield_df.loc[i, fragment_string] = dfield_df.loc[i, fragment_string] + \
-                                                                      ufield_df.loc[i, fragment_string]
+            dfield_df.loc[i, fragment_string] = dfield[i, fragment - 1].sum(axis=0)
+            ufield_df.loc[i, fragment_string] = ufield[i, fragment - 1].sum(axis=0)
+            totfield_df.loc[i, fragment_string] = (
+                dfield_df.loc[i, fragment_string] + ufield_df.loc[i, fragment_string]
+            )
 
     # Pairwise probe calculation - Get avg electric field
     count = 0
     for i in range(len(probes)):
-        for j in range(i+1, len(probes)):
+        for j in range(i + 1, len(probes)):
             avg_field = (totfield_df.iloc[i, 2:] + totfield_df.iloc[j, 2:]) / 2
 
-            coord1 = totfield_df.loc[i, 'Probe Coordinates']
-            coord2 = totfield_df.loc[j, 'Probe Coordinates']
+            coord1 = totfield_df.loc[i, "Probe Coordinates"]
+            coord2 = totfield_df.loc[j, "Probe Coordinates"]
             # Unit vector
             dir_vec = (coord2 - coord1) / np.linalg.norm(coord2 - coord1)
 
-            #print(avg_field)
+            # print(avg_field)
 
             efield_at_point = []
             label = []
             for column_name, column_value in avg_field.iteritems():
-                efield_at_point.append(np.dot(column_value, dir_vec)*conversion_factor)
+                efield_at_point.append(
+                    np.dot(column_value, dir_vec) * conversion_factor
+                )
                 label.append(column_name)
                 count += 1
             series = pd.Series(efield_at_point, index=label)
             output = pd.concat([output, series], axis=1)
             cols = list(output.columns)
-            cols[-1] = F'{probes[i]} and {probes[j]} - frame {snap_num}'
+            cols[-1] = f"{probes[i]} and {probes[j]} - frame {snap_num}"
             output.columns = cols
 
     return output
@@ -163,7 +170,7 @@ if __name__ == "__main__":
     ###########################################################################
 
     start = time.time()
-    
+
     parser = create_parser()
     args = parser.parse_args()
     nengines = args.nengines
@@ -181,7 +188,9 @@ if __name__ == "__main__":
     probes = [int(x) for x in args.probes.split()]
 
     if args.byres and args.bymol:
-        parser.error("--byres and --bymol cannot be used together. Please only use one.")
+        parser.error(
+            "--byres and --bymol cannot be used together. Please only use one."
+        )
 
     if args.byres:
         residues = process_pdb(args.byres)[0]
@@ -189,10 +198,10 @@ if __name__ == "__main__":
     engine_comm = connect_to_engines(nengines)
 
     # Print the probe atoms
-    print(F"Probes: {probes}")
+    print(f"Probes: {probes}")
 
     elapsed = time.time() - start
-    print(F'Setup:\t {elapsed}')
+    print(f"Setup:\t {elapsed}")
 
     ###########################################################################
     #
@@ -203,14 +212,14 @@ if __name__ == "__main__":
     # Get the number of atoms
     mdi.MDI_Send_Command("<NATOMS", engine_comm[0])
     natoms_engine = mdi.MDI_Recv(1, mdi.MDI_INT, engine_comm[0])
-    print(F"natoms: {natoms_engine}")
+    print(f"natoms: {natoms_engine}")
 
     # Get the number of multipole centers
     mdi.MDI_Send_Command("<NPOLES", engine_comm[0])
     npoles = mdi.MDI_Recv(1, mdi.MDI_INT, engine_comm[0])
     print("npoles: " + str(npoles))
 
-    # Get the indices of the mulitpole centers per atom
+    # Get the indices of the multipole centers per atom
     mdi.MDI_Send_Command("<IPOLES", engine_comm[0])
     ipoles = mdi.MDI_Recv(natoms_engine, mdi.MDI_INT, engine_comm[0])
 
@@ -220,8 +229,7 @@ if __name__ == "__main__":
 
     # Get the residue information
     # Residue information comes from pdb.
-    print(F'Initial Info to Tinker:\t {elapsed}')
-
+    print(f"Initial Info to Tinker:\t {elapsed}")
 
     ###########################################################################
     #
@@ -241,26 +249,26 @@ if __name__ == "__main__":
 
     start = time.time()
 
-    probe_pole_indices = [int(ipoles[atom_number-1]) for atom_number in probes]
-    print(F'Probe pole indices {probe_pole_indices}')
+    probe_pole_indices = [int(ipoles[atom_number - 1]) for atom_number in probes]
+    print(f"Probe pole indices {probe_pole_indices}")
 
     # Get the atom and pole numbers for the molecules/residues of interest.
     atoms_pole_numbers = []
     if args.bymol:
-        by_type = 'molecule'
+        by_type = "molecule"
         fragment_list = molecules
     elif args.byres:
-        by_type = 'residue'
+        by_type = "residue"
         fragment_list = residues
     else:
-        by_type = 'atom'
+        by_type = "atom"
         # We are interested in all of the atoms.
-        fragment_list = list(range(1,natoms_engine+1))
+        fragment_list = list(range(1, natoms_engine + 1))
 
     atoms_pole_numbers, from_fragment = index_fragments(fragment_list, ipoles)
 
     elapsed = time.time() - start
-    print(F'Bookkeeping:\t {elapsed}')
+    print(f"Bookkeeping:\t {elapsed}")
 
     ###########################################################################
     #
@@ -275,9 +283,9 @@ if __name__ == "__main__":
         mdi.MDI_Send_Command(">PROBES", comm)
         mdi.MDI_Send(probe_pole_indices, len(probes), mdi.MDI_INT, comm)
 
-    angstrom_to_bohr = mdi.MDI_Conversion_Factor("angstrom","atomic_unit_of_length")
+    angstrom_to_bohr = mdi.MDI_Conversion_Factor("angstrom", "atomic_unit_of_length")
     elapsed - time.time() - start
-    print(F'Sending info to tinker:\t {elapsed}')
+    print(f"Sending info to Tinker:\t {elapsed}")
 
     ###########################################################################
     #
@@ -287,7 +295,7 @@ if __name__ == "__main__":
 
     # Check that engine and trajectory are compatible.
     # Process first two lines of snapshot to get information.
-    with open(snapshot_filename,"r") as snapshot_file:
+    with open(snapshot_filename, "r") as snapshot_file:
         first_line = snapshot_file.readline()
         natoms = int(first_line.split()[0])
         second_line = snapshot_file.readline().split()
@@ -299,8 +307,10 @@ if __name__ == "__main__":
             skip_line = 1
 
     if natoms != natoms_engine:
-        raise Exception(F"Snapshot file and engine have inconsistent number of atoms \
-                            Engine : {natoms_engine} \n Snapshot File : {natoms}")
+        raise Exception(
+            f"Snapshot file and engine have inconsistent number of atoms \
+                            Engine : {natoms_engine} \n Snapshot File : {natoms}"
+        )
 
     ###########################################################################
     #
@@ -313,12 +323,21 @@ if __name__ == "__main__":
 
     itask = 0
     itask_to_snap_num = {}
-    snapshot_coords = [ None for iengine in range(nengines) ]
+    snapshot_coords = [None for iengine in range(nengines)]
 
     # Read trajectory and do analysis
-    for snap_num, snapshot in enumerate(pd.read_csv(snapshot_filename, chunksize=natoms+skip_line,
-        header=None, delim_whitespace=True, names=range(15),
-        skiprows=skip_line, index_col=None), 1):
+    for snap_num, snapshot in enumerate(
+        pd.read_csv(
+            snapshot_filename,
+            chunksize=natoms + skip_line,
+            header=None,
+            delim_whitespace=True,
+            names=range(15),
+            skiprows=skip_line,
+            index_col=None,
+        ),
+        1,
+    ):
 
         if snap_num > equil:
             if (snap_num - equil) % stride == 0:
@@ -332,11 +351,22 @@ if __name__ == "__main__":
                 # Pull out just coords, convert to numeric and use conversion factor.
                 # columns 2-4 of the pandas dataframe are the coordinates.
                 # Must create a copy to send to MDI.
-                snapshot_coords[icomm] = (snapshot.iloc[:natoms , 2:5].apply(pd.to_numeric) *
-                    angstrom_to_bohr).to_numpy().copy()
+                snapshot_coords[icomm] = (
+                    (
+                        snapshot.iloc[:natoms, 2:5].apply(pd.to_numeric)
+                        * angstrom_to_bohr
+                    )
+                    .to_numpy()
+                    .copy()
+                )
 
                 mdi.MDI_Send_Command(">COORDS", engine_comm[icomm])
-                mdi.MDI_Send(snapshot_coords[icomm], 3*natoms, mdi.MDI_DOUBLE, engine_comm[icomm])
+                mdi.MDI_Send(
+                    snapshot_coords[icomm],
+                    3 * natoms,
+                    mdi.MDI_DOUBLE,
+                    engine_comm[icomm],
+                )
 
                 # Get the electric field information
                 # mdi.MDI_Send_Command("<FIELD", engine_comm)
@@ -347,27 +377,38 @@ if __name__ == "__main__":
                 # Get the pairwise DFIELD
                 # Note: We only send the command here; we do NOT wait for Tinker to finish the calculation
                 # This allows us to farm out tasks to each of the engines simultaneously
-                dfield = np.zeros((len(probes),npoles,3))
+                dfield = np.zeros((len(probes), npoles, 3))
                 mdi.MDI_Send_Command("<DFIELD", engine_comm[icomm])
 
                 # After every engine has received a task, collect the data
                 if (icomm % nengines) == (nengines - 1):
                     for jcomm in range(nengines):
-                        output = collect_task(engine_comm[jcomm], npoles, snapshot_coords[jcomm],
-                                              itask_to_snap_num[itask - nengines + jcomm], atoms_pole_numbers, output)
+                        output = collect_task(
+                            engine_comm[jcomm],
+                            npoles,
+                            snapshot_coords[jcomm],
+                            itask_to_snap_num[itask - nengines + jcomm],
+                            atoms_pole_numbers,
+                            output,
+                        )
 
                     elapsed_dfield = time.time() - start_dfield
-                    print(F"DField Retrieval:\t {elapsed_dfield}")
+                    print(f"DField Retrieval:\t {elapsed_dfield}")
 
     # Collect any tasks that have not yet been collected
-    for icomm in range ( itask % nengines ):
-        output = collect_task(engine_comm[icomm], npoles, snapshot_coords[icomm],
-                              itask_to_snap_num[itask - nengines + jcomm], output)
+    for icomm in range(itask % nengines):
+        output = collect_task(
+            engine_comm[icomm],
+            npoles,
+            snapshot_coords[icomm],
+            itask_to_snap_num[itask - nengines + jcomm],
+            output,
+        )
 
-    output.to_csv('proj_totfield.csv')
+    output.to_csv("proj_totfield.csv")
 
     elapsed = time.time() - start
-    print(F'Elapsed loop:{elapsed}')#
+    print(f"Elapsed loop:{elapsed}")  #
 
     # Send the "EXIT" command to the engine
     for comm in engine_comm:

--- a/ELECTRIC/ELECTRIC.py
+++ b/ELECTRIC/ELECTRIC.py
@@ -402,6 +402,7 @@ if __name__ == "__main__":
             npoles,
             snapshot_coords[icomm],
             itask_to_snap_num[itask - nengines + jcomm],
+            atoms_pole_numbers,
             output,
         )
 

--- a/ELECTRIC/residue_report.py
+++ b/ELECTRIC/residue_report.py
@@ -10,7 +10,7 @@ import argparse
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('pdb_file', help='The pdb file to analyze.')
+    parser.add_argument("pdb_file", help="The pdb file to analyze.")
 
     args = parser.parse_args()
 

--- a/ELECTRIC/util.py
+++ b/ELECTRIC/util.py
@@ -244,7 +244,7 @@ def index_fragments(fragment_list, ipoles):
     for fragment in fragments:
         # These are the atom numbers for the atoms in the specified molecules
         fragment_atoms = np.array(np.where(fragment_list == fragment)) + 1
-        # The pole indices for the speified molecule
+        # The pole indices for the specified molecule
         pole_numbers = [ipoles[atom_index - 1] for atom_index in fragment_atoms[0]]
         atoms_pole_numbers.append(np.array(pole_numbers))
 

--- a/ELECTRIC/util.py
+++ b/ELECTRIC/util.py
@@ -1,8 +1,8 @@
-
 import numpy as np
 import pandas as pd
 
 import argparse
+
 
 def create_parser():
     """
@@ -10,58 +10,86 @@ def create_parser():
     """
 
     # Handle arguments with argparse
-    parser = argparse.ArgumentParser(add_help=False,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    required = parser.add_argument_group('Required Arguments')
-    optional = parser.add_argument_group('optional arguments')
+    parser = argparse.ArgumentParser(
+        add_help=False, formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    required = parser.add_argument_group("Required Arguments")
+    optional = parser.add_argument_group("optional arguments")
 
     # Add back help
     optional.add_argument(
-        '-h',
-        '--help',
-        action='help',
-        help='show this help message and exit'
+        "-h", "--help", action="help", help="show this help message and exit"
     )
 
-    required.add_argument("-mdi", help='flags for mdi. When in doubt, `-mdi "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost", type=str, required=True` is a good option.')
-    required.add_argument("-snap", help="The file name of the trajectory to analyze.", type=str,
-        required=True)
+    required.add_argument(
+        "-mdi",
+        help='flags for mdi. When in doubt, `-mdi "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost", type=str, required=True` is a good option.',
+    )
+    required.add_argument(
+        "-snap",
+        help="The file name of the trajectory to analyze.",
+        type=str,
+        required=True,
+    )
 
-    required.add_argument("-probes", help='''
+    required.add_argument(
+        "-probes",
+        help="""
                 Atom indices which are probes for the electric field calculations. 
                 For example, if you would like to calculate the electric field along 
-                the bond between atoms 1 and 2, you would use `-probes "1 2"`.''', type=str, required=True)
+                the bond between atoms 1 and 2, you would use `-probes "1 2"`.""",
+        type=str,
+        required=True,
+    )
 
-    optional.add_argument("-nengines", help="""
+    optional.add_argument(
+        "--nengines",
+        help="""
                 This option allows the driver to farm tasks out to multiple Tinker 
                 engines simultaneously, enabling parallelization of the electric field analysis 
                 computation. The argument to this option **must** be equal to the number of
-                Tinker engines that are launched along with the driver.""", type=int,
-                default=1)
+                Tinker engines that are launched along with the driver.""",
+        type=int,
+        default=1,
+    )
 
-
-    optional.add_argument("--equil", help='''
+    optional.add_argument(
+        "--equil",
+        help="""
                 'The number of frames to skip performing analysis on
                 at the beginning of the trajectory file (given by the -snap argument)
                 For example, using --equil 50 will result in analysis starting after frame 50 of the trajectory, 
-                (in other words, the first frame which will be analyzed is frame 50 + stride).''',
-                type=int, default=0)
+                (in other words, the first frame which will be analyzed is frame 50 + stride).""",
+        type=int,
+        default=0,
+    )
 
-    optional.add_argument("--stride", help='''
+    optional.add_argument(
+        "--stride",
+        help="""
                 The number of frames to skip between analysis calculations. For example, using --stride 2 would
-                result in analysis of every other frame in the trajectory.''',
-                type=int, default=1)
+                result in analysis of every other frame in the trajectory.""",
+        type=int,
+        default=1,
+    )
 
-    optional.add_argument("--byres", help='''
+    optional.add_argument(
+        "--byres",
+        help="""
                 Flag which indicates electric field
                 at the probe atoms should be calculated with electric field contributions given
                 per residue. If --byres is indicated, the argument should be followed
-                by the filename for a pdb file which gives residues.''')
+                by the filename for a pdb file which gives residues.""",
+    )
 
-    optional.add_argument("--bymol", help='''
+    optional.add_argument(
+        "--bymol",
+        help="""
                 Flag which indicates electric field
                 at the probe atoms should be calculated with electric field contributions given
-                per molecule.''', action="store_true")
+                per molecule.""",
+        action="store_true",
+    )
 
     return parser
 
@@ -82,10 +110,13 @@ def process_pdb(file_path, group_solvent=True):
     -------
     residues : list
         A list of size n_atoms where each element gives the residue number that atom belongs to.
+
+    residue_names : list
+        A list of residue names.
     """
 
-    solvent_residues = ['wat', 'na+', 'cl-', 'hoh', 'na', 'cl']
-    accepted_names = ['HETATM', 'ATOM']
+    solvent_residues = ["wat", "na+", "cl-", "hoh", "na", "cl"]
+    accepted_names = ["HETATM", "ATOM"]
 
     # Determine the number of lines to skip.
     with open(file_path) as f:
@@ -93,19 +124,32 @@ def process_pdb(file_path, group_solvent=True):
         line_number = 0
         while not found:
             line = f.readline().split()
-            if len(line)>0:
+            if len(line) > 0:
                 line = line[0]
-            if 'ATOM' in line or 'HETATM' in line:
+            if "ATOM" in line or "HETATM" in line:
                 found = True
             else:
-                line_number +=1
+                line_number += 1
 
-    pdb = pd.read_fwf(file_path, skiprows=line_number, header=None, colspecs=((0,6),
-                                                          (6,12), (12, 16), (16,17),
-                                                          (17,20), (21, 22), (22, 27),
-                                                          (27,28)), dtype=str, keep_default_na=False)
-    pdb = pdb[[0,4,6]]
-    pdb.columns = ['record type','res name', 'residue number']
+    pdb = pd.read_fwf(
+        file_path,
+        skiprows=line_number,
+        header=None,
+        colspecs=(
+            (0, 6),
+            (6, 12),
+            (12, 16),
+            (16, 17),
+            (17, 20),
+            (21, 22),
+            (22, 27),
+            (27, 28),
+        ),
+        dtype=str,
+        keep_default_na=False,
+    )
+    pdb = pdb[[0, 4, 6]]
+    pdb.columns = ["record type", "res name", "residue number"]
     pdb.dropna(inplace=True)
 
     residue_number = 1
@@ -114,55 +158,66 @@ def process_pdb(file_path, group_solvent=True):
     residues = []
     residue_names = []
     for row in pdb.iterrows():
-        now_number = row[1]['residue number']
-        now_name = row[1]['res name']
-        record_type = row[1]['record type']
+        now_number = row[1]["residue number"]
+        now_name = row[1]["res name"]
+        record_type = row[1]["record type"]
         if record_type in accepted_names:
             if previous != now_number and previous is not None:
-                if not (group_solvent) or \
-                            (group_solvent and previous_name.lower() not in solvent_residues) or \
-                                (group_solvent and now_name.lower() not in solvent_residues):
+                if (
+                    not (group_solvent)
+                    or (group_solvent and previous_name.lower() not in solvent_residues)
+                    or (group_solvent and now_name.lower() not in solvent_residues)
+                ):
                     residue_number += 1
 
             if now_name.lower() in solvent_residues:
-                residue_names.append('solvent')
+                residue_names.append("solvent")
             else:
                 residue_names.append(now_name)
 
             residues.append(residue_number)
         previous = now_number
         previous_name = now_name
-    
+
     return residues, residue_names
 
 
 def print_info(pdb_file):
     """
-    Print info from process_pdb function.
+    Print residue information for pdb file.
+
+    Parameters
+    ----------
+    pdb_file : str
+        The path to the pdb file for which to print residue information.
+
+    Returns
+    -------
+    report : str
+        A string containing information about the residues in the pdb.
     """
     atom_residues, names = process_pdb(pdb_file)
 
-
     atom_residues = np.array(atom_residues)
 
-    report = F'''
+    report = f"""
     {pdb_file} processed. 
-    Found {len(atom_residues)} atoms and {atom_residues[-1]} residues.\n'''
+    Found {len(atom_residues)} atoms and {atom_residues[-1]} residues.\n"""
 
     # Add two because this gives the index before the change (1), another because atom numbering starts at 1, and indexing starts at 0.
-    residue_index = np.where(atom_residues[:-1] != atom_residues[1:])[0] + 2 
+    residue_index = np.where(atom_residues[:-1] != atom_residues[1:])[0] + 2
 
-    report += F'{"Residue Number":<20} {"Starting atom":<20} {"Residue Name":<20}\n'
-    report += F'{"1":^20} {"1":^20} {names[0]:^20}\n'
+    report += f'{"Residue Number":<20} {"Starting atom":<20} {"Residue Name":<20}\n'
+    report += f'{"1":^20} {"1":^20} {names[0]:^20}\n'
 
     for count, residue in enumerate(residue_index):
-        report += F"{count+2:^20} {residue:^20} {names[residue]:^20}\n"
-    
+        report += f"{count+2:^20} {residue:^20} {names[residue]:^20}\n"
+
     return report
 
 
 def index_fragments(fragment_list, ipoles):
-    '''
+    """
     Calculates the pole index of atom numbers given in fragment list.
 
     Parameters
@@ -177,7 +232,10 @@ def index_fragments(fragment_list, ipoles):
     -------
     atoms_pole_numbers : list
         A multidimensional list where each element gives the pole indices in that fragment.
-    '''
+
+    fragments : list
+        A list of the fragment numbers.
+    """
     # Get the atom and pole numbers for the molecules/residues of interest.
     atoms_pole_numbers = []
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can see command line arguments for this driver using the following command f
 Here is the help information for the command line arguments:
 
     usage: ELECTRIC.py [-h] -mdi MDI -snap SNAP -probes PROBES
-                              [-nengines NENGINES] [--equil EQUIL]
+                              [--nengines NENGINES] [--equil EQUIL]
                               [--stride STRIDE] [--byres BYRES] [--bymol]
 
     required arguments:
@@ -139,7 +139,7 @@ Here is the help information for the command line arguments:
 
     optional arguments:
       -h, --help          show this help message and exit
-      -nengines NENGINES  This option allows the driver to farm tasks out to
+      --nengines NENGINES This option allows the driver to farm tasks out to
                           multiple Tinker engines simultaneously, enabling
                           parallelization of the electric field analysis
                           computation. The argument to this option **must** be

--- a/docs/_ext/dataTables.py
+++ b/docs/_ext/dataTables.py
@@ -13,6 +13,7 @@ from sphinx.util.docutils import SphinxDirective
 class data_table(nodes.General, nodes.Element):
     pass
 
+
 class DataTable(SphinxDirective):
 
     has_content = True
@@ -21,14 +22,14 @@ class DataTable(SphinxDirective):
         settings = {}
 
         for content in self.content:
-            split_content = content.split(':', 1)
-            settings[split_content[0].strip() ] = split_content[1].strip()
+            split_content = content.split(":", 1)
+            settings[split_content[0].strip()] = split_content[1].strip()
 
         node = data_table()
-        node.table_id = F'table-{self.env.new_serialno("table")}'
+        node.table_id = f'table-{self.env.new_serialno("table")}'
         node.settings = settings
 
-        with open(settings['csv_file']) as f:
+        with open(settings["csv_file"]) as f:
             reader = csv.reader(f)
 
             for count, row in enumerate(reader):
@@ -39,18 +40,19 @@ class DataTable(SphinxDirective):
                     node.data.append(row)
         return [node]
 
+
 def html_visit_output_node(self, node):
 
     # Build HTML table
 
     table_string = ""
 
-    table_string += F"<table id='{node.table_id}' class='display'>\n"
+    table_string += f"<table id='{node.table_id}' class='display'>\n"
     table_string += "\t<thead>\n\t\t<tr>\n"
 
     for header in node.headers:
-        table_string += F"\t\t\t<th>{header}</th>\n"
-    
+        table_string += f"\t\t\t<th>{header}</th>\n"
+
     table_string += "</tr></thead>\n<tbody>\n"
 
     for row in node.data:
@@ -58,11 +60,11 @@ def html_visit_output_node(self, node):
         for entry in row:
             try:
                 numeric_entry = float(entry)
-                entry = F"{numeric_entry:.3f}"
+                entry = f"{numeric_entry:.3f}"
             except ValueError:
                 entry = entry
 
-            table_string += F"\t\t\t<td>{entry}</td>\n"
+            table_string += f"\t\t\t<td>{entry}</td>\n"
         table_string += "\t</tr>\n"
 
     table_string += "\t</tbody>"
@@ -70,9 +72,10 @@ def html_visit_output_node(self, node):
 
     self.body.append(table_string)
 
+
 def html_depart_output_node(self, node):
 
-    initialize_table_script = F"""<script>
+    initialize_table_script = f"""<script>
 
     $(document).ready( function () {{
             $('#{node.table_id}').DataTable({{"ordering": false, "paging": false}});}} );
@@ -83,24 +86,17 @@ def html_depart_output_node(self, node):
     self.body.append(initialize_table_script)
 
 
-
-
-
 def setup(app):
 
     app.add_node(
         data_table,
-        html=(
-            html_visit_output_node,
-            html_depart_output_node
-        ),
+        html=(html_visit_output_node, html_depart_output_node),
     )
 
     app.add_directive("datatable", DataTable)
 
     return {
-        'version': '0.1',
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }
-

--- a/docs/_ext/moleculeView.py
+++ b/docs/_ext/moleculeView.py
@@ -11,22 +11,24 @@ from sphinx.util.docutils import SphinxDirective
 class view(nodes.General, nodes.Element):
     pass
 
+
 class MoleculeView(SphinxDirective):
 
     has_content = True
 
     def run(self):
-        view_id = F'viewport-{self.env.new_serialno("view")}' 
+        view_id = f'viewport-{self.env.new_serialno("view")}'
         settings = {}
 
         for content in self.content:
-            split_content = content.split(':', 1)
-            settings[split_content[0] ] = split_content[1]
+            split_content = content.split(":", 1)
+            settings[split_content[0]] = split_content[1]
 
         node = view()
         node.view_id = view_id
         node.settings = settings
         return [node]
+
 
 def html_visit_output_node(self, node):
 
@@ -34,44 +36,45 @@ def html_visit_output_node(self, node):
         "data-backgroundcolor": "white",
         "width": "400px",
         "height": "300px",
-        "data-style": "stick"
+        "data-style": "stick",
     }
 
-    if 'data-pdb' not in node.settings and 'data-href' not in node.settings:
+    if "data-pdb" not in node.settings and "data-href" not in node.settings:
         raise KeyError("You must specify a path to a pdb or file to visualize.")
-    
-    if 'data-pdb' and 'data-href' in node.settings:
+
+    if "data-pdb" and "data-href" in node.settings:
         raise ValueError("You should only specify one molecule file to visualize.")
 
     for k, v in node.settings.items():
         k = k.strip()
         defaults[k] = v.strip()
 
-    source_string = ''
+    source_string = ""
 
-    if 'data-pdb' in defaults:
-        source_string = F'data-pdb={defaults["data-pdb"]}'
-    elif 'data-href' in defaults:
-        source_string = F'data-href={defaults["data-href"]}'
+    if "data-pdb" in defaults:
+        source_string = f'data-pdb={defaults["data-pdb"]}'
+    elif "data-href" in defaults:
+        source_string = f'data-href={defaults["data-href"]}'
 
     # Set data styles
-    data_style = ''
+    data_style = ""
 
     # Process extra styles
-    style_keys = [k for k in defaults.keys() if 'style' in k]
-    select_keys = [k for k in defaults.keys() if 'select' in k]
-    
+    style_keys = [k for k in defaults.keys() if "style" in k]
+    select_keys = [k for k in defaults.keys() if "select" in k]
+
     for i in range(len(style_keys)):
         style_key = style_keys[i]
-        data_style += F" {style_key}={defaults[style_key]} "
-    
+        data_style += f" {style_key}={defaults[style_key]} "
+
     for i in range(len(select_keys)):
         select_key = select_keys[i]
-        data_style += F" {select_key}={defaults[select_key]} "
+        data_style += f" {select_key}={defaults[select_key]} "
 
-    show_string = F'<center><div style="height: {defaults["height"]}; width: {defaults["width"]}; position: relative;" class="viewer_3Dmoljs" {source_string} data-backgroundcolor="{defaults["data-backgroundcolor"]}" {data_style}></div></center>'
+    show_string = f'<center><div style="height: {defaults["height"]}; width: {defaults["width"]}; position: relative;" class="viewer_3Dmoljs" {source_string} data-backgroundcolor="{defaults["data-backgroundcolor"]}" {data_style}></div></center>'
 
     self.body.append(show_string)
+
 
 def html_depart_output_node(self, node):
     pass
@@ -81,17 +84,13 @@ def setup(app):
 
     app.add_node(
         view,
-        html=(
-            html_visit_output_node,
-            html_depart_output_node
-        ),
+        html=(html_visit_output_node, html_depart_output_node),
     )
 
     app.add_directive("moleculeview", MoleculeView)
 
     return {
-        'version': '0.1',
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": "0.1",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'ELECTRIC'
-copyright = '2020, Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn'
-author = 'Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn'
+project = "ELECTRIC"
+copyright = "2020, Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn"
+author = "Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn"
 
 
 # -- General configuration ---------------------------------------------------
@@ -27,16 +27,15 @@ author = 'Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -58,10 +57,11 @@ html_theme = "sphinx_rtd_theme"
 # Custom directives
 sys.path.append(os.path.abspath("./_ext"))
 
-extensions = ["moleculeView", "dataTables", "sphinx_rtd_theme", 'sphinxarg.ext']
+extensions = ["moleculeView", "dataTables", "sphinx_rtd_theme", "sphinxarg.ext"]
+
 
 def setup(app):
-    app.add_js_file('https://3dmol.org/build/3Dmol-min.js')
-    app.add_js_file('https://code.jquery.com/jquery-3.5.1.min.js')
-    app.add_js_file('https://cdn.datatables.net/1.10.22/js/jquery.dataTables.js')
-    app.add_css_file('https://cdn.datatables.net/1.10.22/css/jquery.dataTables.css')
+    app.add_js_file("https://3dmol.org/build/3Dmol-min.js")
+    app.add_js_file("https://code.jquery.com/jquery-3.5.1.min.js")
+    app.add_js_file("https://cdn.datatables.net/1.10.22/js/jquery.dataTables.js")
+    app.add_css_file("https://cdn.datatables.net/1.10.22/css/jquery.dataTables.css")

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,7 +34,7 @@ One possible launch command would be:
 
 .. code-block:: bash
 
-    `python ${DRIVER_LOC} -probes "1 2 10" -snap coordinates.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" --byres ke15.pdb --equil 51 -nengines 15 &`
+    `python ${DRIVER_LOC} -probes "1 2 10" -snap coordinates.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" --byres ke15.pdb --equil 51 --nengines 15 &`
 
 where `DRIVER_LOC` is the path to ELECTRIC.py which you set during the configuration step. See the section :ref:`electric settings` for a detailed explanation of command line arguments for ELECTRIC.
 
@@ -68,7 +68,7 @@ Example Script
     done
 
     # launch the driver
-    python ${DRIVER_LOC} -probes "32 33 59 60" -snap coordinates.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" --byres ke15.pdb --equil 51 -nengines ${nengines} &
+    python ${DRIVER_LOC} -probes "32 33 59 60" -snap coordinates.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" --byres ke15.pdb --equil 51 --nengines ${nengines} &
 
     wait
 


### PR DESCRIPTION
This PR addresses several points from #25 .

> The code seems very clean and concise, very good work. Here are a few notes.
> 
> ## Electric
> ## File: Electric.py
> * [x]  a general note is to adopt a formatting standard and list this in the contributing, such as autopep8 or black. This would also belong in the CONTRIBUTING.md, or wherever you choose to discuss community contributions as discussed in #17. This may already be done on your end, but just worth a mention for the community aspect.

- black has been run on `ELECTRIC.py`, `util.py`, and `residue_report.py`
- `CONTRIBUTING.md` has been added to the top level of the directory. This is based on the MolSSI CookieCutter as suggested and includes information about running black.

> ### function: `mdi_checks`:
> * [x]  need to define input arguments in documentation.
> 
> ### function: `collect_task`:
> * [x]  define input/output argument data types and definitions.
> * [x]  npoles from_fragment seem to be used by the function collect_task, though instead of being passed as a parameter to the function it is inferred from the definition in main, which is hard to follow and could lead to problems in development and a tricker time at debugging for other contributors.

Most of these were addressed in #26 . The function `mdi_checks` has been renamed to `connect_to_engines`. This PR fixes the `from_fragment` argument in  `collect_task`

> ### function: main
> * [x]  capitalization of Tinker on line 241
> * [x]  line 174: multipole misspelled.

These typos have been corrected.

> ## File: Util.py
> ### function: `create_parser`
> * [x]  Consistency among optional argument dashes. More specifically `-nengines` only required one dash where as every other requires two.

This has been updated to use two dashes (`--`) since it is an optional argument. Documentation has been updated as well.

> ### function: `print_info`
> * [x]  adding a description for the input argument for consistency.
> 
> ### function: `index fragment`
> * [x]  only one of the return arguments is explained.
> * [x]  "specified" is misspelled in the comments


These descriptions/spelling mistakes are corrected.