### PR TITLE
Engine parallelism testing

### DIFF
--- a/ELECTRIC/pytest/bench5/test_simulation.py
+++ b/ELECTRIC/pytest/bench5/test_simulation.py
@@ -130,3 +130,39 @@ def test_bench5_equil_stride():
     ref_totfield = ref_totfield[proj_totfield.columns]
 
     pd.testing.assert_frame_equal(ref_totfield, proj_totfield)
+
+def test_nengines():
+    # get the name of the codes
+    driver_path = os.path.join(mypath, "../../ELECTRIC.py")
+    engine_path = os.path.join(mypath, "../../../modules/Tinker/build/tinker/source/dynamic.x")
+
+    nengines = 2
+
+    # run the calculation
+    driver_proc = subprocess.Popen([sys.executable, driver_path, 
+                                    "-probes", "1 40", "-snap", "bench5.arc", 
+                                    "-mdi", "-role DRIVER -name driver -method TCP -port 8021"
+                                    "--bymol","--nengines", str(nengines)],
+                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=mypath)
+    engine_procs = []
+    for iengine in range(nengines):
+        engine_procs.append( subprocess.Popen([engine_path, "bench5", "-k", "no_ewald.key", 
+                                               "-mdi", "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost",
+                                               "10", "1.0", "0.001999", "2", "300.00"],
+                                              cwd=mypath) )
+    driver_tup = driver_proc.communicate()
+    engine_tups = []
+    for iengine in range(nengines):
+        engine_tups.append( engine_procs[iengine].communicate() )
+
+    # convert the driver's output into a string
+    driver_out = format_return(driver_tup[0])
+    driver_err = format_return(driver_tup[1])
+
+    # validate proj_totfield.csv against ref_totfield.csv
+    ref_totfield_path = os.path.join(mypath, "ref_totfield.csv")
+    proj_totfield_path = os.path.join(mypath, "proj_totfield.csv")
+    ref_totfield = pd.read_csv(ref_totfield_path)
+    proj_totfield = pd.read_csv(proj_totfield_path)
+
+    pd.testing.assert_frame_equal(ref_totfield, proj_totfield)


### PR DESCRIPTION
This PR adds a new test to `ELECTRIC/pytest/bench5/test_simulation.py` that runs an analysis using two engines.