### PR TITLE
update gha workflow event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v1
-
-    - name: Checkout submodules
-      uses: textbook/git-checkout-submodule-action@master
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     #- name: Setup Miniconda
     #  uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Add `workflow_dispatch` event to GHA so that workflow can be manually triggered.

The checkout action is also updated to version 2 and configured to pull submodules. This is suggested by the documentation for the previous action we were using for submodules, which has been archived. https://github.com/textbook/git-checkout-submodule-action