### PR TITLE
Add tolerances to test_simulation.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,7 @@ test/locations/Tinker_ELECTRIC
 
 # Documentation builds
 _build/
+
+# ELECTRIC FILES
+ELECTRIC/mdi/MDI_Library/mdi_name
+ELECTRIC/mdi/__init__.py

--- a/ELECTRIC/pytest/bench5/test_simulation.py
+++ b/ELECTRIC/pytest/bench5/test_simulation.py
@@ -44,7 +44,7 @@ def test_bench5():
     ref_totfield = pd.read_csv(ref_totfield_path)
     proj_totfield = pd.read_csv(proj_totfield_path)
 
-    pd.testing.assert_frame_equal(ref_totfield, proj_totfield)
+    pd.testing.assert_frame_equal(ref_totfield, proj_totfield, check_exact=False, atol=0.001)
 
 
 def test_bench5_equil():
@@ -88,7 +88,7 @@ def test_bench5_equil():
 
     ref_totfield = ref_totfield[proj_totfield.columns]
 
-    pd.testing.assert_frame_equal(ref_totfield, proj_totfield)
+    pd.testing.assert_frame_equal(ref_totfield, proj_totfield, check_exact=False, atol=0.001)
 
 def test_bench5_equil_stride():
 
@@ -129,7 +129,7 @@ def test_bench5_equil_stride():
     # make sure values match reference
     ref_totfield = ref_totfield[proj_totfield.columns]
 
-    pd.testing.assert_frame_equal(ref_totfield, proj_totfield)
+    pd.testing.assert_frame_equal(ref_totfield, proj_totfield, check_exact=False, atol=0.001)
 
 def test_nengines():
     # get the name of the codes
@@ -165,4 +165,4 @@ def test_nengines():
     ref_totfield = pd.read_csv(ref_totfield_path)
     proj_totfield = pd.read_csv(proj_totfield_path)
 
-    pd.testing.assert_frame_equal(ref_totfield, proj_totfield)
+    pd.testing.assert_frame_equal(ref_totfield, proj_totfield, check_exact=False, atol=0.001)

--- a/test/traj/tcp.sh
+++ b/test/traj/tcp.sh
@@ -23,6 +23,6 @@ export OMP_NUM_THREADS=1
 ${TINKER_LOC} traj_out.051 -k no_ewald.key -mdi "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost" 10 1.0 0.001999 2 300.00 > no_ewald.log &
 
 #launch driver
-python ${DRIVER_LOC} -probes [48042,48043,48044,48051] -snap traj_out.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" &
+python ${DRIVER_LOC} -probes "48042 48043 48044 48051" -snap traj_out.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" &
 
 wait


### PR DESCRIPTION
Tinker version 8.10 produces slightly different results from Tinker version 8.8.  In order to accommodate this and potential future changes due to Tinker updates, this PR adds a finite tolerance to the tests.