### PR TITLE
Oct 2023 update

### DIFF
--- a/ELECTRIC/ELECTRIC.py
+++ b/ELECTRIC/ELECTRIC.py
@@ -130,7 +130,7 @@ def collect_task(comm, npoles, snapshot_coords, snap_num, atoms_pole_numbers, ou
 
             efield_at_point = []
             label = []
-            for column_name, column_value in avg_field.iteritems():
+            for column_name, column_value in avg_field.items():
                 efield_at_point.append(
                     np.dot(column_value, dir_vec) * conversion_factor
                 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Build Status](https://travis-ci.com/WelbornGroup/ELECTRIC.svg?branch=master)](https://travis-ci.com/WelbornGroup/ELECTRIC)
 [![codecov](https://codecov.io/gh/WelbornGroup/ELECTRIC/branch/master/graph/badge.svg)](https://codecov.io/gh/WelbornGroup/ELECTRIC)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/WelbornGroup/ELECTRIC.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/WelbornGroup/ELECTRIC/context:python)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.02576/status.svg)](https://doi.org/10.21105/joss.02576)
 
 # ELECTRIC
@@ -15,19 +14,27 @@ MDI-enabled Tinker and this driver.
 
 Using this tool, you can calculate the electric field along a bond or between atoms due to molecules or residues in the system.
 
+
 ### Compiling MDI-Tinker and ELECTRIC
 
-Installation of ELECTRIC and MDI-enabled Tinker are bundled in one convenient build script. 
-
-To install ELECTRIC and MDI-enabled Tinker, you should have cmake and a fortran compiler installed. Then, you can download and build ELECTRIC and MDI-enabled Tinker using the following command in your terminal. Make sure you are in the directory where you want your ELECTRIC driver to be. You should note this location, because you will need to specify the path to some files built during this process in order to perform analysis.
+To get started with ELECTRIC, you should first clone this repository:
 
 ```
 git clone --recurse-submodules https://github.com/WelbornGroup/ELECTRIC.git
-cd ELECTRIC
-./build.sh
 ```
 
-This will download and build ELECTRIC and MDI-enabled Tinker.
+If you are using `conda`, you can create an environment with the appropriate dependencies using the provided `environment.yaml` file:
+
+```
+cd ELECTRIC
+conda env create -f environment.yaml
+```
+
+Installation of ELECTRIC and MDI-enabled Tinker are bundled in one convenient build script. 
+
+```
+./build.sh
+```
 
 In certain environments, it may be necessary to manually set the compilers.
 This can be done when calling the `build.sh` script.
@@ -43,11 +50,9 @@ Upon successfull building, you will have the ELECTRIC driver in ELECTRIC/ELECTRI
 
 ### Python Dependencies
 
-In order to run ELECTRIC, you will need to be in a python environment which has numpy and pandas installed. We recommend installing these packages in a conda environment created for ELECTRIC analysis.
-
-``` 
-conda install -c conda-forge numpy pandas
-```
+In order to run ELECTRIC, you will need to be in a python environment which has numpy and pandas installed.
+If you are using `conda`, the provided environment.yaml and created environment will have the necessary dependencies. 
+If you are not using the provided conda environment, you will need to make sure that  you have [NumPy](https://numpy.org/) and [pandas](https://pandas.pydata.org/) installed to use ELECTRIC.
 
 ## Testing
 
@@ -135,8 +140,6 @@ This approach is likely to be preferable when running on large supercomputing cl
 Note that on systems that manage MPI jobs using SLURM, it is necessary to use `srun` to launch jobs rather than direct calls to `mpiexec`.
 Example scripts for launching on NERSC's Cori system are provided at `ELECTRIC/test/bench5/cori.sh` (for running with a single instance of Tinker) and `ELECTRIC/test/bench5/cori5.sh` (for running with multiple instances of Tinker).
 Before running one of these scripts, you will need to change the `--account` SBATCH option to your own account.
-
-
 
 
 ## Command-Line Options

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = "ELECTRIC"
-copyright = "2020, Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn"
+copyright = "2020-2023, Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn"
 author = "Jessica A. Nash, Taylor A. Barnes, Valerie Vaissier Welborn"
 
 
@@ -57,7 +57,7 @@ html_theme = "sphinx_rtd_theme"
 # Custom directives
 sys.path.append(os.path.abspath("./_ext"))
 
-extensions = ["moleculeView", "dataTables", "sphinx_rtd_theme", "sphinxarg.ext"]
+extensions = ["moleculeView", "dataTables", "sphinx_rtd_theme", "sphinxarg.ext", "sphinx_copybutton"]
 
 
 def setup(app):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,54 +2,79 @@ Installation
 ============
 
 Compiling MDI-Tinker and ELECTRIC
-----------------------------------
+---------------------------------
 
-Installation of ELECTRIC and MDI-enabled Tinker are bundled in one convenient build script. 
+.. note::
+    The following instructions assume that you are using the `conda <https://docs.conda.io/en/latest/>`_ package manager and a Linux or Unix based operating system. 
+    If you are not using :code:`conda`, you will need to install the dependencies manually.
+    If you are using the Windows Operating System, we recommend the Windows Subsystem for Linux (WSL).
 
-To install ELECTRIC and MDI-enabled Tinker, you should have cmake and a fortran compiler installed. Then, you can download and build ELECTRIC and MDI-enabled Tinker using the following command in your terminal. Make sure you are in the directory where you want your ELECTRIC driver to be. You should note this location, because you will need to specify the path to some files built during this process in order to perform analysis.
+To install ELECTRIC and MDI-enabled Tinker, you should have :code:`cmake` and a Fortran compiler installed. 
+If you are using the `conda` package manager, you can clone the repository and use the provided `environment.yaml` 
+to create an environment with the required dependencies (including Python packages) using the following command.
 
 .. code-block:: bash
 
     git clone --recurse-submodules https://github.com/WelbornGroup/ELECTRIC.git
     cd ELECTRIC
+    conda create -f environment.yaml
+
+After the environment is created and installed you should activate it:
+
+.. code-block:: bash
+
+    conda activate electric
+
+After creating and activating your environment, you will have the necessary compilers and libraries required for compilating, installing, and running ELECTRIC.
+Installation of ELECTRIC and MDI-enabled Tinker are bundled in one convenient build script. 
+Execute the following command in the top level of your cloned repository to build ELECTRIC and MDI-enabled Tinker:
+
+.. code-block:: bash
+
     ./build.sh
 
-This will download and build ELECTRIC and MDI-enabled Tinker. 
 
-Upon successful building, you will have the ELECTRIC driver in ELECTRIC/ELECTRIC/ELECTRIC.py, and the needed Tinker executable (dynamic.x) in ELECTRIC/modules/Tinker/build/tinker/source/dynamic.x . The location of these files can be found in text files in ELECTRIC/test/locations/ELECTRIC and ELECTRIC/test/locations/Tinker_ELECTRIC. You will need these for using ELECTRIC.
-
-Python Dependencies
--------------------
-
-In order to run ELECTRIC, you will need to be in a python environment which has numpy and pandas installed. If you want to run ELECTRIC with more than one engine, you should also install MPI4Py. We recommend installing these packages in a conda environment created for ELECTRIC analysis.
-
-.. code-block:: bash   
-
-    conda install -c anaconda mpi4py
-    conda install -c conda-forge numpy pandas
+Upon successful building, you will have the ELECTRIC driver in :code:`ELECTRIC/ELECTRIC/ELECTRIC.py`, 
+and the needed Tinker executable (:code:`dynamic.x`) in ELECTRIC/modules/Tinker/build/tinker/source/dynamic.x . 
+The location of these files can be found in text files in :code:`ELECTRIC/test/locations/ELECTRIC` and :code:`ELECTRIC/test/locations/Tinker_ELECTRIC`.
+You will need these for using ELECTRIC.
 
 Testing Your Installation
 --------------------------
 
-You can now run a quick test of the driver by changing directory to the `ELECTRIC/test/bench5` directory and running the `tcp.sh` script:
+To continue with testing your installation, make sure your `electric` `conda` environment is activated:
 
 .. code-block:: bash
 
+    conda activate electric
+
+You can now run a quick test of the driver by changing directory to the :code:`ELECTRIC/test/bench5` directory and running the `tcp.sh` script:
+
+.. code-block:: bash
+
+    cd ELECTRIC/test/bench5
     ./tcp.sh
 
-This script will run a short Tinker dynamics simulation that includes periodic boundary conditions. This command is on line 20 of the provided file. This is a standard Tinker call, as you would normally run a simulation. If you are performing post processing on a simulation, you will not use this line.
+This script will run a short Tinker dynamics simulation that includes periodic boundary conditions. 
+This command is on line 20 of the provided file. This is a standard Tinker call, as you would normally run a simulation. 
+If you are performing post processing on a simulation, you will not use this line.
 
 .. code-block:: bash
 
     ${TINKER_LOC} bench5 -k bench5.key 10 1.0 0.001999 2 300.00 > Dynamics.log
 
-The script then launches an instance of Tinker as an MDI engine, which will request a connection to the driver and then listen for commands from the driver. This command is similar to running a simulation with Tinker, except that it uses a modified Tinker input file (more on this below), and adds an additional command line argument which passes information to MDI (`-mdi "role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost"`):
+The script then launches an instance of Tinker as an MDI engine, 
+which will request a connection to the driver and then listen for commands from the driver. 
+This command is similar to running a simulation with Tinker, except that it uses a modified Tinker input file 
+(more on this below), and adds an additional command line argument which passes information to MDI 
+(`-mdi "role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost"`):
 
 .. code-block:: bash
 
     ${TINKER_LOC} bench5 -k no_ewald.key -mdi "-role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost" 10 1.0 0.001999 2 300.00 > no_ewald.log &
 
-The script will then launch an instance of the driver in the background, which will listen for connections from an MDI engine:
+The script will then launch an instance of the driver in the background, 
+which will listen for connections from an MDI engine:
 
 .. code-block:: bash
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx_rtd_theme
 sphinx-argparse
+sphinx-copybutton
 numpy
 pandas

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -12,7 +12,7 @@ If you don't, navigate to the installation_ instructions.
         - You are able to download or clone a directory from git.
         - You are familiar with bash scripts.
 
-To begin thee tutorial, first make sure you have your `electric` environment activated:
+To begin the tutorial, first make sure you have your `electric` environment activated:
 
 .. code-block:: bash
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,7 +1,9 @@
 Tutorial
 ========
 
-This tutorial will walk you through using ELECTRIC to analyze the electric field in a small protein. This tutorial assumes you have ELECTRIC and MDI-enabled Tinker installed. If you don't, navigate to the installation_ instructions.
+This tutorial will walk you through using ELECTRIC to analyze the electric field in a small protein. 
+This tutorial assumes you have ELECTRIC and MDI-enabled Tinker installed. 
+If you don't, navigate to the installation_ instructions.
 
 .. note::
     This tutorial will assume the following:
@@ -10,8 +12,16 @@ This tutorial will walk you through using ELECTRIC to analyze the electric field
         - You are able to download or clone a directory from git.
         - You are familiar with bash scripts.
 
+To begin thee tutorial, first make sure you have your `electric` environment activated:
 
-The pdb code for this protein is 1l2y_, and you can see the structure below. We have chosen a small protein for demonstrative purposes. The image below shows only the protein, but our simulation is solvated.
+.. code-block:: bash
+
+    conda activate electric
+
+
+The pdb code for this protein is 1l2y_, and you can see the structure below. 
+We have chosen a small protein for demonstrative purposes. 
+The image below shows only the protein, but our simulation is solvated.
 
 .. moleculeView:: 
     
@@ -26,9 +36,13 @@ Running an ELECTRIC calculation
 
 Preparing Files
 ----------------
-To follow along with this tutorial, clone the `tutorial repository`_. Included in this repository is folder called :code:`data`. The :code:`data` directory has all of the data you will need for this tutorial.
+To follow along with this tutorial, clone the `tutorial repository`_. 
+Included in this repository is folder called :code:`data`. The :code:`data` directory has all of the data you will need for this tutorial.
 
-ELECTRIC is a post-processing analysis, meaning that you should first run your simulations using the AMOEBA forcefield and save the trajectory. After you have a trajectory from Tinker simulation, use ELECTRIC to perform electric field analysis on that trajectory. We will be analyzing the trajectory included in the tutorial repository, :code:`1l2y_npt.arc`. This trajectory is a text file containing coordinates for a simulation that has already been run.
+ELECTRIC is a post-processing analysis, meaning that you should first run your simulations using the AMOEBA forcefield and save the trajectory. 
+After you have a trajectory from Tinker simulation, use ELECTRIC to perform electric field analysis on that trajectory. 
+We will be analyzing the trajectory included in the tutorial repository, :code:`1l2y_npt.arc`. 
+This trajectory is a text file containing coordinates for a simulation that has already been run.
 
 To get started with ELECTRIC, we will need to prepare our input files. We will need:
     - a molecular dynamics trajectory
@@ -40,11 +54,15 @@ We already have the molecular dynamics trajectory, so let's look at each of thes
 
 Simulation Parameter File
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-This file contains the force field parameters for the simulation you have run. If you are using this software for analysis, use the same force field you used to run the molecular dynamics simulation. For this tutorial, the parameter file is :code:`amoebabio18.prm`. We will need this for our Tinker input file (next section).
+This file contains the force field parameters for the simulation you have run. If you are using this software for analysis, use the same force field you used to run the molecular dynamics simulation. 
+For this tutorial, the parameter file is :code:`amoebabio18.prm`. We will need this for our Tinker input file (next section).
 
 Tinker input file
 ^^^^^^^^^^^^^^^^^
-Next, we must prepare an input file which tells Tinker settings for our calculation. This input file should be a modified version of the one which you used to run your initial simulation. Consider the input file, :code:`tinker.key` used to obtain this trajectory. The parameter file in the previous step is given on :code:`line 1`.
+Next, we must prepare an input file which tells Tinker settings for our calculation. 
+This input file should be a modified version of the one which you used to run your initial simulation. 
+Consider the input file, :code:`tinker.key` used to obtain this trajectory. 
+The parameter file in the previous step is given on :code:`line 1`.
 
 .. code-block:: text
     :linenos:
@@ -73,11 +91,15 @@ Next, we must prepare an input file which tells Tinker settings for our calculat
     printout 1000
 
 
-The input file used for this simulation uses periodic boundaries and an Ewald summation for electrostatics. During a Tinker simulation using AMOEBA, electric fields are evaluated in order to calculate the induced dipoles at each step. In order to get electric field contributions from specific residues, we must calculate the electric field using the real space interactions only (no periodic boundaries or Ewald). 
+The input file used for this simulation uses periodic boundaries and an Ewald summation for electrostatics. 
+During a Tinker simulation using AMOEBA, electric fields are evaluated in order to calculate the induced dipoles at each step. 
+In order to get electric field contributions from specific residues, we must calculate the electric field using the real space interactions only (no periodic boundaries or Ewald). 
 
-Remove settings related to cutoffs (:code:`cutoff` keyword), periodic boundaries (:code:`a-axis`, :code:`b-axis`,:code:`c-axis`) and Ewald summation (:code:`ewald`). You can also remove settings having to do with neighbor lists (:code:`neighbor-list`), as they are not needed and can cause an error for this calculation if included.
+Remove settings related to cutoffs (:code:`cutoff` keyword), periodic boundaries (:code:`a-axis`, :code:`b-axis`,:code:`c-axis`) and Ewald summation (:code:`ewald`). 
+You can also remove settings having to do with neighbor lists (:code:`neighbor-list`), as they are not needed and can cause an error for this calculation if included.
 
-The modifed input file for ELECTRIC is given below. This file is saved in the data directory with the name :code:`noewald.key`.
+The modifed input file for ELECTRIC is given below. 
+This file is saved in the data directory with the name :code:`noewald.key`.
 
 .. code-block:: text
 
@@ -99,9 +121,12 @@ The modifed input file for ELECTRIC is given below. This file is saved in the da
 
 Bash script - run_analysis.sh
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When you run analysis uisng ELECTRIC, ELECTRIC parses your given trajectory sends snapshots to Tinker for electric field calculation. The MDI-enabled version of Tinker then calculates the electric field information for that snapshot. 
+When you run analysis uisng ELECTRIC, ELECTRIC parses your given trajectory sends snapshots to Tinker for electric field calculation. 
+The MDI-enabled version of Tinker then calculates the electric field information for that snapshot. 
 
-You use ELECTRIC from the command line. Consider the following bash script provided for analysis, :code:`run_analysis.sh`. We will explain this script in detail.
+You use ELECTRIC from the command line. 
+Consider the following bash script provided for analysis, :code:`run_analysis.sh`. 
+We will explain this script in detail.
 
 .. code-block:: bash
     :linenos:
@@ -134,9 +159,11 @@ You use ELECTRIC from the command line. Consider the following bash script provi
 
     For this tutorial, we use the approach of having all data needed for analysis in a directory called `data`. During analysis, we copy everything from :code:`data` into a folder :code:`work`. This part of the tutorial is stylistic. The authors prefer this method to keep files separated, and original files unaltered.
 
-In lines :code:`2` and :code:`3`, you should change the location to your installed ELECTRIC.py file and MDI-enabled :code:`dynamic.x`. Recall from the installation instructions that you can find these in the ELECTRIC directory in the files :code:`ELECTRIC/test/locations/ELECTRIC` and :code:`ELECTRIC/test/locations/Tinker_ELECTRIC`. 
+In lines :code:`2` and :code:`3`, you should change the location to your installed ELECTRIC.py file and MDI-enabled :code:`dynamic.x`. 
+Recall from the installation instructions that you can find these in the ELECTRIC directory in the files :code:`ELECTRIC/test/locations/ELECTRIC` and :code:`ELECTRIC/test/locations/Tinker_ELECTRIC`. 
 
-The next section removes the folder called :code:`work` if it exists. This bash script is written to put all analysis files into a folder called :code:`work` to keep our original files clean. 
+The next section removes the folder called :code:`work` if it exists. 
+This bash script is written to put all analysis files into a folder called :code:`work` to keep our original files clean. 
 
 MDI-enabled Tinker is launched on :code:`line 18` with the command
 
@@ -144,7 +171,15 @@ MDI-enabled Tinker is launched on :code:`line 18` with the command
 
     ${TINKER_LOC} 1l2y -k no_ewald.key -mdi "-role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost"  10 1.0 0.002 2 300.00 > no_ewald.log &
 
-The first thing on this line, :code:`${TINKER_LOC}` fills in the location for :code:`dynamic.x` which you put in line 2. Next, `1l2y` is the file name (without an extension) of the xyz file for this calculation (provided vile :code:`12ly.xyz`). You should have this from your original simulation. However, make sure that there is no box information on line two of this :code:`xyz` file, as this could cause Tinker to use periodic boundaries. Next, we give the input file (key file) we have prepared in the previous step using :code:`-k noewald.key`. Then, we give our MDI options. The given options should work for most analysis. After the MDI options are some Tinker input options. For our analysis, it will not really matter what we put here since we are running calculations on one snapshot at a time. However, you must have these present for Tinker to run. Very importantly, note the ampersand (:code:`&`) at the end of this line. This will launch Tinker in the background, where it will be waiting for commands from ELECTRIC.
+The first thing on this line, :code:`${TINKER_LOC}` fills in the location for :code:`dynamic.x` which you put in line 2. 
+Next, `1l2y` is the file name (without an extension) of the xyz file for this calculation (provided vile :code:`12ly.xyz`). 
+You should have this from your original simulation. 
+However, make sure that there is no box information on line two of this :code:`xyz` file, as this could cause Tinker to use periodic boundaries. 
+Next, we give the input file (key file) we have prepared in the previous step using :code:`-k noewald.key`. 
+Then, we give our MDI options. 
+The given options should work for most analysis. After the MDI options are some Tinker input options. 
+For our analysis, it will not really matter what we put here since we are running calculations on one snapshot at a time. 
+However, you must have these present for Tinker to run. Very importantly, note the ampersand (:code:`&`) at the end of this line. This will launch Tinker in the background, where it will be waiting for commands from ELECTRIC.
 
 .. warning::
     
@@ -156,12 +191,15 @@ In the next command (:code:`line 21`), we launch ELECTRIC.
 
     python ${DRIVER_LOC} -snap 1l2y_npt.arc -probes "78 93 94"  -mdi "-role DRIVER -name driver -method TCP -port 8022" --byres 1l2y_solvated.pdb  --equil 120 --stride 2 &
 
-Here, we first give the location of our ELECTRIC driver. We indicate our trajectory file using the `-snap` argument with the filename to analyze, followed by MDI options.
+Here, we first give the location of our ELECTRIC driver. 
+We indicate our trajectory file using the `-snap` argument with the filename to analyze, followed by MDI options.
 
 Probe Atoms 
 ++++++++++++
 
-To run an ELECTRIC calculation, you must give the indices of your probe atoms. The probe atoms are the atoms which are used as 'probes' for the electric field. ELECTRIC reports the projected total electric field at the midpoint between all probe atom pairs. This allows you to calculate electric fields along bonds `as reported in literature <https://pubs.acs.org/doi/10.1021/jacs.9b05323>`_.
+To run an ELECTRIC calculation, you must give the indices of your probe atoms. 
+The probe atoms are the atoms which are used as 'probes' for the electric field. ELECTRIC reports the projected total electric field at the midpoint between all probe atom pairs. 
+This allows you to calculate electric fields along bonds `as reported in literature <https://pubs.acs.org/doi/10.1021/jacs.9b05323>`_.
 
 You should obtain the number of the probe atoms from the :code:`xyz` file you use to launch MDI-enabled Tinker. Note that the index you use here should match the number given in the first column of your xyz file. The projection of the electric field at the midpoint of these two atoms will be reported for each analyzed frame. If you indicate more than two probes, all pairwise fields will be reported (ie, if using "78 93 94", you will get "78 and 93", "78 and 94" and "93 and 94"). You can see the atoms we have chosen as probes highlighted below:
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,11 @@
+name: electric
+channels:
+  - conda-forge
+dependencies:
+  - cmake
+  - gfortran
+  - mpi4py
+  - numpy
+  - pandas
+  - jupyterhub
+  - matplotlib


### PR DESCRIPTION
## Description
This PR makes updates to ELECTRIC:

* `iteritems` is changed to `items` in ELECTRIC. `iteritems` has been deprecated and the replacement is `items`. Its presence in ELECTRIC is making the script incompatible with newer pandas versions. 
* an `environment.yaml` containing `cmake`, `gfortran` and Python packages is added and instructions for use are added to the docs.
